### PR TITLE
Tweak project settings to better support multiple resolutions/aspect ratios

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -8,11 +8,6 @@
 
 config_version=4
 
-_global_script_classes=[  ]
-_global_script_class_icons={
-
-}
-
 [application]
 
 config/name="Jetpaca"
@@ -34,6 +29,9 @@ gdscript/warnings/enable=false
 
 window/size/width=1280
 window/size/height=720
+window/dpi/allow_hidpi=true
+window/stretch/mode="2d"
+window/stretch/aspect="expand"
 
 [input]
 
@@ -73,6 +71,7 @@ use_pixel_snap=true
 [rendering]
 
 quality/driver/driver_name="GLES2"
-quality/2d/use_pixel_snap=true
+2d/snapping/use_gpu_pixel_snap=true
 vram_compression/import_etc=true
 vram_compression/import_etc2=false
+quality/2d/use_pixel_snap=true


### PR DESCRIPTION
This prevents the UI from looking too small on hiDPI displays, especially on mobile.

This makes the game world more "zoomed in" at higher resolutions, but this is something we could address later by adding a zoom setting, zooming out when moving at high speeds or something similar.

- Upgrade to Godot 3.3.